### PR TITLE
exception when no config file was found, pass commands to context to …

### DIFF
--- a/src/GitHook/Command/Context/CommandContext.php
+++ b/src/GitHook/Command/Context/CommandContext.php
@@ -23,6 +23,11 @@ class CommandContext implements CommandContextInterface
     protected $file;
 
     /**
+     * @var \GitHook\Command\CommandInterface[]
+     */
+    protected $commands;
+
+    /**
      * @param \GitHook\Config\GitHookConfig $config
      *
      * @return \GitHook\Command\Context\CommandContextInterface
@@ -70,6 +75,26 @@ class CommandContext implements CommandContextInterface
     public function getFile()
     {
         return $this->file;
+    }
+
+    /**
+     * @return \GitHook\Command\CommandInterface[]
+     */
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @param \GitHook\Command\CommandInterface[] $commands
+     *
+     * @return $this
+     */
+    public function setCommands(array $commands)
+    {
+        $this->commands = $commands;
+
+        return $this;
     }
 
 }

--- a/src/GitHook/Command/Context/CommandContextInterface.php
+++ b/src/GitHook/Command/Context/CommandContextInterface.php
@@ -43,4 +43,16 @@ interface CommandContextInterface
      */
     public function getFile();
 
+    /**
+     * @return \GitHook\Command\CommandInterface[]
+     */
+    public function getCommands();
+
+    /**
+     * @param \GitHook\Command\CommandInterface[] $commands
+     *
+     * @return $this
+     */
+    public function setCommands(array $commands);
+
 }

--- a/src/GitHook/Command/FileCommand/FileCommandExecutor.php
+++ b/src/GitHook/Command/FileCommand/FileCommandExecutor.php
@@ -44,7 +44,7 @@ class FileCommandExecutor implements CommandExecutorInterface
     public function execute(CommandContextInterface $context)
     {
         $success = true;
-        foreach ($context->getConfig()->getPreCommitFileCommands() as $command) {
+        foreach ($context->getCommands() as $command) {
             $configuration = new CommandConfiguration();
             $configuration = $command->configure($configuration);
 

--- a/src/GitHook/Command/RepositoryCommand/RepositoryCommandExecutor.php
+++ b/src/GitHook/Command/RepositoryCommand/RepositoryCommandExecutor.php
@@ -36,7 +36,7 @@ class RepositoryCommandExecutor implements CommandExecutorInterface
     public function execute(CommandContextInterface $context)
     {
         $success = true;
-        foreach ($context->getConfig()->getPreCommitRepositoryCommands() as $command) {
+        foreach ($context->getCommands() as $command) {
             $configuration = new CommandConfiguration();
             $configuration = $command->configure($configuration);
 

--- a/src/GitHook/Config/GitHookConfig.php
+++ b/src/GitHook/Config/GitHookConfig.php
@@ -56,6 +56,22 @@ class GitHookConfig
     }
 
     /**
+     * @return \GitHook\Command\CommandInterface[]
+     */
+    public function getPrePushRepositoryCommands()
+    {
+        $repositoryCommands = [];
+        if (isset($this->config['prePushRepositoryCommands'])) {
+            foreach ($this->config['prePushRepositoryCommands'] as $repositoryCommand) {
+                $repositoryCommand = '\\' . ltrim($repositoryCommand, '\\');
+                $repositoryCommands[] = new $repositoryCommand;
+            }
+        }
+
+        return $repositoryCommands;
+    }
+
+    /**
      * @param string $commandName
      *
      * @return array

--- a/src/GitHook/Helper/ContextHelper.php
+++ b/src/GitHook/Helper/ContextHelper.php
@@ -7,6 +7,7 @@
 
 namespace GitHook\Helper;
 
+use Exception;
 use GitHook\Command\Context\CommandContext;
 use GitHook\Config\ConfigLoader;
 
@@ -14,12 +15,20 @@ trait ContextHelper
 {
 
     /**
+     * @throws \Exception
+     *
      * @return \GitHook\Command\Context\CommandContextInterface
      */
     public function createContext()
     {
         $context = new CommandContext();
         $configLoader = new ConfigLoader();
+        $configFilePath = realpath(PROJECT_ROOT) . '/.githook';
+
+        if (!file_exists($configFilePath)) {
+            throw new Exception('Could not load ".githook" configuration file. Please add one to the root of your project.');
+        }
+
         $config = $configLoader->getConfig(PROJECT_ROOT . '/.githook');
 
         $context->setConfig($config);

--- a/src/GitHook/Hook/SprykerPreCommit.php
+++ b/src/GitHook/Hook/SprykerPreCommit.php
@@ -38,15 +38,22 @@ class SprykerPreCommit extends Application
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        $context = $this->createContext();
+        $fileCommands = $context->getConfig()->getPreCommitFileCommands();
+        $repositoryCommands = $context->getConfig()->getPreCommitRepositoryCommands();
+
+        if (count($fileCommands) === 0 && count($repositoryCommands) === 0) {
+            return;
+        }
+
         $consoleHelper = new ConsoleHelper($input, $output);
         $consoleHelper->gitHookHeader('Spryker Git pre-commit hook');
 
-        $context = $this->createContext();
-        $committedFiles = $this->getCommittedFiles();
-
-        $fileCommandExecutor = new FileCommandExecutor($committedFiles, $consoleHelper);
+        $context->setCommands($fileCommands);
+        $fileCommandExecutor = new FileCommandExecutor($this->getCommittedFiles(), $consoleHelper);
         $fileCommandSuccess = $fileCommandExecutor->execute($context);
 
+        $context->setCommands($repositoryCommands);
         $repositoryCommandExecutor = new RepositoryCommandExecutor($consoleHelper);
         $repositoryCommandSuccess = $repositoryCommandExecutor->execute($context);
 

--- a/src/GitHook/Hook/SprykerPrePush.php
+++ b/src/GitHook/Hook/SprykerPrePush.php
@@ -35,10 +35,18 @@ class SprykerPrePush extends Application
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        $context = $this->createContext();
+        $commands = $context->getConfig()->getPrePushRepositoryCommands();
+        $context->setCommands($commands);
+
         $consoleHelper = new ConsoleHelper($input, $output);
+
+        if (count($commands) === 0) {
+            return;
+        }
+
         $consoleHelper->gitHookHeader('Spryker Git pre-push hook');
 
-        $context = $this->createContext();
         $repositoryCommandExecutor = new RepositoryCommandExecutor($consoleHelper);
         $repositoryCommandSuccess = $repositoryCommandExecutor->execute($context);
 


### PR DESCRIPTION
Throw exception with help message for not existing .githook configuration.
Added commands to context to be able to use any command inside of the executors.
Fixed bug that pre-commit repository commands were executed on pre-push.