### PR TITLE
TE 36 detect dependency from twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   },
   "require": {
     "php": ">=7.1",
-    "symfony/yaml": "^2.8|^3"
+    "symfony/yaml": "^2.8|^3",
+    "zendframework/zend-filter": "^2.0.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^0.8 || ^0.9",
@@ -27,8 +28,8 @@
     "symfony/var-dumper": "^3.3"
   },
   "autoload": {
-    "psr-0": {
-      "GitHook": "src"
+    "psr-4": {
+      "GitHook\\": "src/"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "autoload": {
     "psr-4": {
-      "GitHook\\": "src/"
+      "GitHook\\": "src/GitHook/"
     }
   },
   "scripts": {

--- a/src/GitHook/Command/FileCommand/PreCommit/DependencyViolationCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/DependencyViolationCheckCommand.php
@@ -56,7 +56,7 @@ class DependencyViolationCheckCommand implements CommandInterface
             return $commandResult;
         }
 
-        $processDefinition = ['vendor/bin/console', 'dev:dependency:find-violations', $module];
+        $processDefinition = ['vendor/bin/console', 'dev:dependency:find', $module];
         $processBuilder = new ProcessBuilder($processDefinition);
         $processBuilder->setWorkingDirectory(PROJECT_ROOT);
         $process = $processBuilder->getProcess();

--- a/src/GitHook/Command/FileCommand/PreCommit/DependencyViolationCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/DependencyViolationCheckCommand.php
@@ -13,6 +13,8 @@ use GitHook\Command\CommandResult;
 use GitHook\Command\Context\CommandContextInterface;
 use GitHook\Helper\ProcessBuilderHelper;
 use Symfony\Component\Process\ProcessBuilder;
+use Zend\Filter\FilterChain;
+use Zend\Filter\Word\DashToCamelCase;
 
 class DependencyViolationCheckCommand implements CommandInterface
 {
@@ -56,7 +58,9 @@ class DependencyViolationCheckCommand implements CommandInterface
             return $commandResult;
         }
 
-        $processDefinition = ['vendor/bin/console', 'dev:dependency:find', $module];
+        $organization = $this->getOrganizationNameFromFile($context->getFile());
+
+        $processDefinition = ['vendor/bin/console', 'dev:dependency:find', sprintf('%s.%s', $organization, $module), '-e'];
         $processBuilder = new ProcessBuilder($processDefinition);
         $processBuilder->setWorkingDirectory(PROJECT_ROOT);
         $process = $processBuilder->getProcess();
@@ -78,12 +82,29 @@ class DependencyViolationCheckCommand implements CommandInterface
      *
      * @return string
      */
-    private function getModuleNameFromFile($fileName)
+    private function getModuleNameFromFile($fileName): string
     {
         $filePathParts = explode(DIRECTORY_SEPARATOR, $fileName);
         $namespacePosition = array_search('Bundles', $filePathParts);
 
         return $filePathParts[$namespacePosition + 1];
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return string
+     */
+    private function getOrganizationNameFromFile($fileName): string
+    {
+        $filePathParts = explode(DIRECTORY_SEPARATOR, $fileName);
+        $vendorPosition = array_search('vendor', $filePathParts);
+
+        $organizationName = $filePathParts[$vendorPosition + 1];
+        $filterChain = new FilterChain();
+        $filterChain->attach(new DashToCamelCase());
+
+        return $filterChain->filter($organizationName);
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-36

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   GitHook               | patch (new)           |                       |

#### Release Notes

Previously there was a wrong psr-0 definition in the composer.json file, this is fixed now. The Command to check the dependencies for modules where changed files are detected is also changed to use the new console command.

-----------------------------------------

#### Module GitHook

_**Patch:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] The change is isolated and not mixed with any cleanups or other changes.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Initial Release

- Fixed psr-o to psr-4 namespace.
- Updated DependencyViolationCheckCommand.

