### PR TITLE
MP-66 Make internal tools work on the marketplace namespace

### DIFF
--- a/src/GitHook/Composer/Scripts/HookInstaller.php
+++ b/src/GitHook/Composer/Scripts/HookInstaller.php
@@ -170,4 +170,28 @@ class HookInstaller
 
         return true;
     }
+
+    /**
+     * @param \Composer\Script\Event $event
+     *
+     * @return bool
+     */
+    public static function installSprykerMerchantPortalHooks(Event $event)
+    {
+        $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
+        $hookDirectory = $vendorDir . '/spryker/git-hook/hooks/spryker/';
+        $gitHookDirectory = $vendorDir . '/spryker/spryker-merchant-portal/.git/hooks/';
+
+        foreach (static::$sprykerHooks as $hook) {
+            $src = realpath($hookDirectory . $hook);
+            $dist = realpath($gitHookDirectory) . '/' . $hook;
+
+            copy($src, $dist);
+            chmod($dist, 0755);
+
+            $event->getIO()->write(sprintf('<info>Copied "%s" to "%s"</info>', $src, $dist));
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/MP-66

Related PRs:
[spryker/spryker#4760](https://github.com/spryker/spryker/pull/4760)

Minor:
[spryker-sdk/spryk-gui#12](https://github.com/spryker-sdk/spryk-gui/pull/12)
[spryker-sdk/phpstan-spryker#8](https://github.com/spryker-sdk/phpstan-spryker/pull/8)
[spryker-sdk/spryk#12](https://github.com/spryker-sdk/spryk/pull/12)
[spryker/git-hook#25](https://github.com/spryker/git-hook/pull/25)
[spryker/spryker-shop#794](https://github.com/spryker/spryker-shop/pull/794)

Suites:
[spryker/suite-nonsplit#1823](https://github.com/spryker/suite-nonsplit/pull/1823)
[spryker/merchant-portal-nonsplit#2](https://github.com/spryker/merchant-portal-nonsplit/pull/2)