### PR TITLE
TE-1947 Run phpmd checks only on directories not on files.

### DIFF
--- a/src/GitHook/Command/FileCommand/PreCommit/ArchitectureCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/ArchitectureCheckCommand.php
@@ -19,6 +19,11 @@ class ArchitectureCheckCommand implements CommandInterface
     use ProcessBuilderHelper;
 
     /**
+     * @var string[]
+     */
+    protected $processedDirectories;
+
+    /**
      * @param \GitHook\Command\CommandConfigurationInterface $commandConfiguration
      *
      * @return \GitHook\Command\CommandConfigurationInterface
@@ -43,9 +48,15 @@ class ArchitectureCheckCommand implements CommandInterface
         $configuration = new ArchitectureSniffConfiguration($context->getCommandConfig('architecture'));
         $commandResult = new CommandResult();
 
+        $directory = dirname($context->getFile());
+
+        if (isset($this->processedDirectories[$directory])) {
+            return $commandResult;
+        }
+
         $processDefinition = [
             'vendor/bin/phpmd',
-            $context->getFile(),
+            $directory,
             'xml',
             'vendor/spryker/architecture-sniffer/src/ruleset.xml',
             '--minimumpriority',
@@ -60,6 +71,8 @@ class ArchitectureCheckCommand implements CommandInterface
                 ->setError(trim($process->getErrorOutput()))
                 ->setMessage(trim($process->getOutput()));
         }
+
+        $this->processedDirectories[$directory] = true;
 
         return $commandResult;
     }

--- a/src/GitHook/Command/FileCommand/PreCommit/PhpMdCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/PhpMdCheckCommand.php
@@ -19,6 +19,11 @@ class PhpMdCheckCommand implements CommandInterface
     use ProcessBuilderHelper;
 
     /**
+     * @var string[]
+     */
+    protected $processedDirectories;
+
+    /**
      * @param \GitHook\Command\CommandConfigurationInterface $commandConfiguration
      *
      * @return \GitHook\Command\CommandConfigurationInterface
@@ -43,9 +48,15 @@ class PhpMdCheckCommand implements CommandInterface
         $configuration = new PhpMdCheckConfiguration($context->getCommandConfig('phpmd'));
         $commandResult = new CommandResult();
 
+        $directory = dirname($context->getFile());
+
+        if (isset($this->processedDirectories[$directory])) {
+            return $commandResult;
+        }
+
         $processDefinition = [
             'vendor/bin/phpmd',
-            $context->getFile(),
+            $directory,
             'xml',
             'vendor/spryker/spryker/Bundles/Development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
             '--minimumpriority',
@@ -60,6 +71,8 @@ class PhpMdCheckCommand implements CommandInterface
                 ->setError(trim($process->getErrorOutput()))
                 ->setMessage(trim($process->getOutput()));
         }
+
+        $this->processedDirectories[$directory] = true;
 
         return $commandResult;
     }


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-1946

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   GitHook               | patch (currently 0.0.x)  |                       |

#### Release Notes

Previously, we run PHPMd checks for each file, this is now changed to run only for directories.

-----------------------------------------

#### Module GitHook

##### Change log

Initial Release

- Run PHPMd command only for directories.

