### PR TITLE
TE-5102: Git hook incorrect ruleset path

### DIFF
--- a/src/GitHook/Command/FileCommand/PreCommit/PhpMd/PhpMdCheckConfiguration.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/PhpMd/PhpMdCheckConfiguration.php
@@ -7,6 +7,8 @@
 
 namespace GitHook\Command\FileCommand\PreCommit\PhpMd;
 
+use Exception;
+
 class PhpMdCheckConfiguration
 {
     /**
@@ -33,5 +35,33 @@ class PhpMdCheckConfiguration
         }
 
         return (isset($this->config['priority'])) ? $this->config['priority'] : $defaultPriority;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRulesetPath(): string
+    {
+        return $this->config['rulesetPath'] ?? $this->getDefaultRulesetPath();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultRulesetPath(): string
+    {
+        $defaultRuleSetPathsByPriority = [
+            'config/phpmd-ruleset.xml',
+            'vendor/spryker/spryker/Bundles/Development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
+            'vendor/spryker/development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml'
+        ];
+
+        foreach ($defaultRuleSetPathsByPriority as $ruleSetPath) {
+            if (file_exists(PROJECT_ROOT . DIRECTORY_SEPARATOR . $ruleSetPath)) {
+                return $ruleSetPath;
+            }
+        }
+
+        throw new Exception('Ruleset file was not found in any location: ' . PHP_EOL . implode(PHP_EOL, $defaultRuleSetPathsByPriority));
     }
 }

--- a/src/GitHook/Command/FileCommand/PreCommit/PhpMd/PhpMdCheckConfiguration.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/PhpMd/PhpMdCheckConfiguration.php
@@ -17,6 +17,15 @@ class PhpMdCheckConfiguration
     protected $config;
 
     /**
+     * @var string[]
+     */
+    protected $defaultRuleSetPathsByPriority = [
+        'config/phpmd-ruleset.xml',
+        'vendor/spryker/spryker/Bundles/Development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
+        'vendor/spryker/development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
+    ];
+
+    /**
      * @param array $config
      */
     public function __construct(array $config)
@@ -52,18 +61,12 @@ class PhpMdCheckConfiguration
      */
     protected function getDefaultRulesetPath(): string
     {
-        $defaultRuleSetPathsByPriority = [
-            'config/phpmd-ruleset.xml',
-            'vendor/spryker/spryker/Bundles/Development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
-            'vendor/spryker/development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
-        ];
-
-        foreach ($defaultRuleSetPathsByPriority as $ruleSetPath) {
+        foreach ($this->defaultRuleSetPathsByPriority as $ruleSetPath) {
             if (file_exists(PROJECT_ROOT . DIRECTORY_SEPARATOR . $ruleSetPath)) {
                 return $ruleSetPath;
             }
         }
 
-        throw new Exception('Ruleset file was not found in any location: ' . PHP_EOL . implode(PHP_EOL, $defaultRuleSetPathsByPriority));
+        throw new Exception('Ruleset file was not found in any location: ' . PHP_EOL . implode(PHP_EOL, $this->defaultRuleSetPathsByPriority));
     }
 }

--- a/src/GitHook/Command/FileCommand/PreCommit/PhpMd/PhpMdCheckConfiguration.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/PhpMd/PhpMdCheckConfiguration.php
@@ -46,6 +46,8 @@ class PhpMdCheckConfiguration
     }
 
     /**
+     * @throws \Exception
+     *
      * @return string
      */
     protected function getDefaultRulesetPath(): string
@@ -53,7 +55,7 @@ class PhpMdCheckConfiguration
         $defaultRuleSetPathsByPriority = [
             'config/phpmd-ruleset.xml',
             'vendor/spryker/spryker/Bundles/Development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
-            'vendor/spryker/development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml'
+            'vendor/spryker/development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
         ];
 
         foreach ($defaultRuleSetPathsByPriority as $ruleSetPath) {

--- a/src/GitHook/Command/FileCommand/PreCommit/PhpMdCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/PhpMdCheckCommand.php
@@ -59,7 +59,7 @@ class PhpMdCheckCommand implements CommandInterface
             'vendor/bin/phpmd',
             $directory,
             'xml',
-            'vendor/spryker/spryker/Bundles/Development/src/Spryker/Zed/Development/Business/PhpMd/ruleset.xml',
+            $configuration->getRulesetPath(),
             '--minimumpriority',
             $configuration->getMinimumPriority(),
         ];
@@ -70,7 +70,7 @@ class PhpMdCheckCommand implements CommandInterface
         if (!$process->isSuccessful()) {
             $commandResult
                 ->setError(trim($process->getErrorOutput()))
-                ->setMessage(trim($process->getOutput()));
+                ->setMessage(trim($process->getOutput() ?: $process->getErrorOutput()));
         }
 
         $this->processedDirectories[$directory] = true;


### PR DESCRIPTION
- Developer(s): @artem-png 

- Ticket: https://spryker.atlassian.net/browse/TE-5102

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/2100


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   GitHook               | patch (currently 0.0.x)  |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module GitHook

##### Change log

Bugfix

- Hardcoded ruleset.xml file for phpmd can be overridden by passing `rulesetPath` in config.

