### PR TITLE
Fixed GitAddCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ preCommitRepositoryCommands:
     - GitHook\Command\RepositoryCommand\PreCommit\GitAddCommand
 ```
 
-See the full list of available commands in the `src/GitHook/Command/FileCommand` and `src/GitHook/Command/RepositoryCommand`.
+See the full list of available commands in `src/GitHook/Command/FileCommand/` and `src/GitHook/Command/RepositoryCommand/`.
 
 Note: `GitHook\Command\RepositoryCommand\PreCommit\GitAddCommand` will automatically add all new files into commit, when other commands changed the files ( `CodeStyleFixCommand` does it for example), so use it only when you really need it!
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ preCommitFileCommands:
     - GitHook\Command\FileCommand\PreCommit\PhpStanCheckCommand
 
 preCommitRepositoryCommands:
+    - GitHook\Command\RepositoryCommand\PreCommit\ValidateBranchNameCommand
     - GitHook\Command\RepositoryCommand\PreCommit\GitAddCommand
 ```
 
+See the full list of available commands in the `src/GitHook/Command/FileCommand` and `src/GitHook/Command/RepositoryCommand`.
+
+Note: `GitHook\Command\RepositoryCommand\PreCommit\GitAddCommand` will automatically add all new files into commit, when other commands changed the files ( `CodeStyleFixCommand` does it for example), so use it only when you really need it!
 
 ### PhpStanCheckCommand configuration
 

--- a/src/GitHook/Command/RepositoryCommand/PreCommit/GitAddCommand.php
+++ b/src/GitHook/Command/RepositoryCommand/PreCommit/GitAddCommand.php
@@ -41,7 +41,7 @@ class GitAddCommand implements CommandInterface
     {
         $commandResult = new CommandResult();
 
-        $process = $this->buildProcess(['git', 'add', '.'], PROJECT_ROOT . PATH_PREFIX);
+        $process = $this->buildProcess(['git', 'add', '--update'], PROJECT_ROOT . PATH_PREFIX);
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
README file updated (warning message)

Fixed `git add` command params to do not add new files (`git add --update`)
