### PR TITLE
[FIX] Improve command output when both error and message exist

### DIFF
--- a/src/GitHook/Command/FileCommand/FileCommandExecutor.php
+++ b/src/GitHook/Command/FileCommand/FileCommandExecutor.php
@@ -90,6 +90,10 @@ class FileCommandExecutor implements CommandExecutorInterface
      */
     protected function getCommandResultErrorMessage(CommandResultInterface $commandResult): string
     {
+        if ($commandResult->getError() && $commandResult->getMessage()) {
+            return sprintf("%s\n%s", $commandResult->getError(), $commandResult->getMessage());
+        }
+
         if ($commandResult->getError()) {
             return $commandResult->getError();
         }


### PR DESCRIPTION
## PR Description

Here is a situation when both error and message exist after PhpStan command execution

![Screenshot from 2021-07-23 17-42-57](https://user-images.githubusercontent.com/11629050/126802813-9e4469eb-7470-4cec-a59e-95acece90695.png)

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
