### PR TITLE
Search for phpcs standard instead of always assuming `config/ruleset.xml`

### DIFF
--- a/src/GitHook/Command/FileCommand/PreCommit/CodeStyleCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/CodeStyleCheckCommand.php
@@ -42,7 +42,8 @@ class CodeStyleCheckCommand implements CommandInterface
     {
         $commandResult = new CommandResult();
 
-        $processDefinition = ['vendor/bin/phpcs', $context->getFile(), '--standard=config/ruleset.xml'];
+        $standard = $this->findStandard(__DIR__);
+        $processDefinition = ['vendor/bin/phpcs', $context->getFile(), '--standard=' . $standard];
         $process = $this->buildProcess($processDefinition);
         $process->run();
 
@@ -53,5 +54,19 @@ class CodeStyleCheckCommand implements CommandInterface
         }
 
         return $commandResult;
+    }
+
+    private function findStandard(string $directory)
+    {
+        $candidates = [
+            implode(DIRECTORY_SEPARATOR, [PROJECT_ROOT, 'config', 'ruleset.xml']),
+            implode(DIRECTORY_SEPARATOR, [PROJECT_ROOT, 'phpcs.xml']),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
+        }
     }
 }

--- a/src/GitHook/Command/FileCommand/PreCommit/CodeStyleCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/CodeStyleCheckCommand.php
@@ -43,7 +43,7 @@ class CodeStyleCheckCommand implements CommandInterface
     {
         $commandResult = new CommandResult();
 
-        $standard = $this->findStandard(__DIR__);
+        $standard = $this->findStandard();
         $processDefinition = ['vendor/bin/phpcs', $context->getFile(), '--standard=' . $standard];
         $process = $this->buildProcess($processDefinition);
         $process->run();
@@ -64,7 +64,7 @@ class CodeStyleCheckCommand implements CommandInterface
      *
      * @return string
      */
-    private function findStandard(string $directory): string
+    private function findStandard(): string
     {
         $candidates = [
             implode(DIRECTORY_SEPARATOR, [PROJECT_ROOT, 'config', 'ruleset.xml']),

--- a/src/GitHook/Command/FileCommand/PreCommit/CodeStyleCheckCommand.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/CodeStyleCheckCommand.php
@@ -13,6 +13,7 @@ use GitHook\Command\CommandResult;
 use GitHook\Command\CommandResultInterface;
 use GitHook\Command\Context\CommandContextInterface;
 use GitHook\Helper\ProcessBuilderHelper;
+use UnexpectedValueException;
 
 class CodeStyleCheckCommand implements CommandInterface
 {
@@ -56,7 +57,14 @@ class CodeStyleCheckCommand implements CommandInterface
         return $commandResult;
     }
 
-    private function findStandard(string $directory)
+    /**
+     * @param string $directory
+     *
+     * @throws \UnexpectedValueException if no file found
+     *
+     * @return string
+     */
+    private function findStandard(string $directory): string
     {
         $candidates = [
             implode(DIRECTORY_SEPARATOR, [PROJECT_ROOT, 'config', 'ruleset.xml']),
@@ -68,5 +76,7 @@ class CodeStyleCheckCommand implements CommandInterface
                 return $candidate;
             }
         }
+
+        throw new UnexpectedValueException('Unable to locate phpcs standard');
     }
 }


### PR DESCRIPTION
## PR Description
phpcs rulesets were recently moved to the project root (as per the phpcs standard). This change allows for both the old placement and the new.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
