### PR TITLE
Fix CodeStyleSniffConfiguration for wrong constant usage

### DIFF
--- a/src/GitHook/Command/FileCommand/PreCommit/CodeStyleSniff/CodeStyleSniffConfiguration.php
+++ b/src/GitHook/Command/FileCommand/PreCommit/CodeStyleSniff/CodeStyleSniffConfiguration.php
@@ -67,7 +67,7 @@ class CodeStyleSniffConfiguration
         $modulePath = $this->getModulePath($context);
 
         if ($modulePath === null) {
-            return APPLICATION_ROOT_DIR . DIRECTORY_SEPARATOR . static::PHPCS_XML_FILE;
+            return PROJECT_ROOT . DIRECTORY_SEPARATOR . static::PHPCS_XML_FILE;
         }
 
         $phpcsFilePath = dirname($modulePath) . DIRECTORY_SEPARATOR . static::PHPCS_XML_FILE;


### PR DESCRIPTION
Fix wrong constant usage since `PROJECT_ROOT` is defined in `hooks/git-hook/pre-commit` but `APPLICATION_ROOT_DIR` isn't. The "undefined" constant leads to an error in the case when $modulePath is null

