### PR TITLE
Change shebang for pre-commit script

### DIFF
--- a/hooks/git-hook/pre-commit
+++ b/hooks/git-hook/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('PROJECT_ROOT', __DIR__ . '/../..');


### PR DESCRIPTION
Since **pre-commit** script can also be run outside `docker/sdk` (e.g. via **git commit** on local env) it can happen that PHP executable is not located in `/usr/bin/php` which will lead so an error in that case. Instead let the system decide where to find the PHP executable by using `/usr/bin/env php` directive