### PR TITLE
Pre Commit Hook should only get affected files which are staged for commit

### DIFF
--- a/src/GitHook/Helper/CommittedFilesHelper.php
+++ b/src/GitHook/Helper/CommittedFilesHelper.php
@@ -46,14 +46,14 @@ trait CommittedFilesHelper
      */
     protected function getAffectedFiles(string $revision): array
     {
-        exec(sprintf('git diff --name-only --diff-filter=AM %s', $revision), $committedFiles);
+        exec(sprintf('git diff --name-only --cached --diff-filter=AM %s', $revision), $committedFiles);
 
         if (!$this->isMergeInProcess()) {
             return $committedFiles;
         }
 
-        exec(sprintf('git diff --name-only --diff-filter=AM MERGE_HEAD...%s', $revision), $mergeConflictFiles);
-        exec(sprintf('git diff --name-only --diff-filter=AM %s MERGE_HEAD', $revision), $mergeFiles);
+        exec(sprintf('git diff --name-only --cached --diff-filter=AM MERGE_HEAD...%s', $revision), $mergeConflictFiles);
+        exec(sprintf('git diff --name-only --cached --diff-filter=AM %s MERGE_HEAD', $revision), $mergeFiles);
 
         return array_merge(array_diff($committedFiles, $mergeFiles), $mergeConflictFiles);
     }


### PR DESCRIPTION
## PR Description

### Current behaviour:
Spryker PreCommit Hook applies on all changed files in working directory

### Expected behaviour:
Spryker PreCommit Hook should only apply on changed files in staging area.
All changed files in working directory do not necessarily have to be relevant for a commit.

### References:
https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgt--cached--merge-baseltcommitgt--ltpathgt82308203

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
