### PR TITLE
Change shebang for php in the hooks

### DIFF
--- a/hooks/eco/pre-commit
+++ b/hooks/eco/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('MODULE_NAME', basename(dirname(__DIR__, 2)));

--- a/hooks/project/pre-commit
+++ b/hooks/project/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('PROJECT_ROOT', __DIR__ . '/../..');

--- a/hooks/spryker-merchant-portal/pre-commit
+++ b/hooks/spryker-merchant-portal/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('PROJECT_ROOT', __DIR__ . '/../../../../..');

--- a/hooks/spryker-shop/pre-commit
+++ b/hooks/spryker-shop/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('PROJECT_ROOT', __DIR__ . '/../../../../..');

--- a/hooks/spryker/pre-commit
+++ b/hooks/spryker/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('PROJECT_ROOT', __DIR__ . '/../../../../..');

--- a/hooks/spryker/pre-push
+++ b/hooks/spryker/pre-push
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 define('PROJECT_ROOT', __DIR__ . '/../../../../..');


### PR DESCRIPTION
This is the follow-up for [PR](https://github.com/spryker/git-hook/pull/59) but for Spryker's internal development.

The PHP binary could be placed in different directories, e.g.

`/usr/local/bin/php` or even `/opt/homebrew/bin/php`

